### PR TITLE
Fix permission.ts compatibility with Directus 10.9.1+

### DIFF
--- a/src/composables/use-permissions.ts
+++ b/src/composables/use-permissions.ts
@@ -57,10 +57,10 @@ export function usePermissions(collection: Ref<string>, item: Ref<any>, isNew: R
 
 		if (userStore.currentUser?.role?.admin_access === true) return fields;
 
-		const permissions = permissionsStore.getPermissionsForUser(collection.value, isNew.value ? 'create' : 'update');
+		const permissions = permissionsStore.getPermission(collection.value, isNew.value ? 'create' : 'update');
 
 		// remove fields without read permissions so they don't show up in the DOM
-		const readableFields = permissionsStore.getPermissionsForUser(collection.value, 'read')?.fields;
+		const readableFields = permissionsStore.getPermission(collection.value, 'read')?.fields;
 		if (readableFields && readableFields.includes('*') === false) {
 			fields = fields.filter((field) => readableFields.includes(field.field));
 		}


### PR DESCRIPTION
[This commit](https://github.com/directus/directus/pull/21152) in the main Directus repository renamed `getPermissionsForUser` to `getPermission` with minor functionality changes. I've updated the call in `src/composables/use-permission.ts` to restore extension functionality on Directus 10.9.1+. 